### PR TITLE
fix: make install prefix configurable; remove hard-coded /usr/local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BUILD = build
+PREFIX ?= /usr/local
 
 all:
 	@cmake -B $(BUILD) -DCMAKE_BUILD_TYPE=RelWithDebInfo
@@ -25,9 +26,9 @@ clean:
 	@rm -rf $(BUILD) $(BUILD)-web
 
 install: release
-	@cmake --install $(BUILD) --prefix /usr/local
+	@cmake --install $(BUILD) --prefix $(PREFIX)
 
 uninstall:
-	@rm -f /usr/local/bin/dawn
+	@rm -f $(PREFIX)/bin/dawn
 
 .PHONY: all release debug with-ai web clean install uninstall


### PR DESCRIPTION
This PR makes the install prefix configurable instead of hard-coding `/usr/local`, while preserving the existing default behavior. Otherwise, this typically fails for non-root users, and may mask downstream bugs.