### PR TITLE
Restore cursor position for reopen

### DIFF
--- a/src/dawn_file.c
+++ b/src/dawn_file.c
@@ -101,8 +101,8 @@ void save_session(void)
 
     DAWN_BACKEND(app)->write_file(app.session_path, content, pos + txt_len);
 
-    // Update history
-    hist_upsert(app.session_path, fm_get_string(fm, "title"));
+    // Update history with cursor position
+    hist_upsert(app.session_path, fm_get_string(fm, "title"), app.cursor);
 
     free(content);
     free(txt);

--- a/src/dawn_fm.c
+++ b/src/dawn_fm.c
@@ -176,8 +176,8 @@ Frontmatter* fm_parse(const char* content, size_t len, size_t* consumed)
     // Calculate consumed bytes
     if (consumed) {
         *consumed = (size_t)((end + 4) - content);
-        // Skip trailing newline after ---
-        if (*consumed < len && content[*consumed] == '\n')
+        // Skip trailing newlines after ---
+        while (*consumed < len && content[*consumed] == '\n')
             (*consumed)++;
     }
 

--- a/src/dawn_history.h
+++ b/src/dawn_history.h
@@ -4,6 +4,7 @@
 #define DAWN_HISTORY_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 // #region Types
@@ -14,6 +15,7 @@ typedef struct {
     char* title; //!< Document title
     int64_t created; //!< Creation timestamp (seconds since epoch)
     int64_t modified; //!< Last modified timestamp
+    size_t cursor; //!< Last cursor position
 } HistEntry;
 
 // #endregion
@@ -40,8 +42,9 @@ void hist_shutdown(void);
 //! Add or update an entry in history
 //! @param path Full path to the document
 //! @param title Document title (can be NULL)
+//! @param cursor Cursor position in document
 //! @return true on success
-bool hist_upsert(const char* path, const char* title);
+bool hist_upsert(const char* path, const char* title, size_t cursor);
 
 //! Remove an entry from history
 //! @param path Full path to remove

--- a/src/dawn_types.h
+++ b/src/dawn_types.h
@@ -148,6 +148,7 @@ typedef struct {
     char* path; //!< Full path to .md file
     char* title; //!< Document title from frontmatter
     char* date_str; //!< Formatted modification date
+    size_t cursor; //!< Last cursor position
 } HistoryEntry;
 
 // #endregion


### PR DESCRIPTION
Scratching my own itch here, I like what you're doing here and I'm really digging the editing experience. One thing that was bothering me is that re-opening files from history sticks the cursor at the top of the file and inserts a newline at the beginning of the file.

This change persists the cursor in the session so that you can pick up writing where you leave off. Not much of a C person so I wouldn't be the least bit troubled if you closed the PR.