### PR TITLE
docs: document input method support (fcitx5, IBus, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,24 @@ The executable will be at `build/Release/dawn.exe`.
 
 ---
 
+
+---
+
+## Input Method Support
+
+Dawn works with input method frameworks (fcitx5, IBus, etc.) through your terminal emulator.
+The terminal handles composition and preedit display; Dawn receives the finalized UTF-8 text.
+
+- **Works with:** fcitx5, IBus, uim, and any IME on both X11 and Wayland
+- **Terminal support:** All modern terminals (GNOME Terminal, Konsole, Alacritty, Kitty, WezTerm, foot, etc.)
+- **No Dawn-specific configuration needed** — if your IME works in `cat`, it works in Dawn
+- **Version requirement:** Dawn 0.11+ (fixes `DAWN_KEY_UP` to accept all Unicode codepoints)
+
+**Troubleshooting:** If Korean/CJK/emoji input does not appear, test with `cat` in the same terminal.
+If characters appear in `cat`, they will appear in Dawn.
+
+---
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary

Adds documentation confirming that Dawn supports input method frameworks (fcitx5, IBus, uim, etc.) for Korean/CJK/emoji input through the terminal emulator.

## What Changed

New **Input Method Support** section added to `README.md`, placed between the Installation and Usage sections.

## Key Points Documented

- Dawn works with fcitx5, IBus, uim, and any IME on both X11 and Wayland
- All modern terminals are supported (GNOME Terminal, Konsole, Alacritty, Kitty, etc.)
- **No Dawn-specific configuration needed** — if your IME works in `cat`, it works in Dawn
- Requires Dawn 0.11+ (the `DAWN_KEY_UP = 0x110000` fix in commit `0e95874` unblocked all Unicode codepoints)
- Troubleshooting guidance: test with `cat` first

## Context

Resolves the discoverability gap for users searching for fcitx5/IME support. The code has supported this since 0.11 (commit `0e95874`), but the README had no mention of it, leaving users to infer from issue threads.

Fixes #28